### PR TITLE
spelling fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "site": {
     "title": "Denys Dovhan",
-    "description": "I'm developer • Student • Speaker • Author • Guitar player • Open Source addict",
+    "description": "I'm a developer • Student • Speaker • Author • Guitar player • Open Source addict",
     "author": "Denys Dovhan",
     "feed_url": "http://denysdovhan.com/rss.xml",
     "site_url": "http://denysdovhan.com/",


### PR DESCRIPTION
If you're using a noun after `I am`, then an article is required. Especially when you're talking about the profession. [Proof](https://ell.stackexchange.com/questions/22471/i-am-without-an-article-with-regard-to-a-job-title).
